### PR TITLE
lb: refactor with the new reactive load balance filter

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -44,6 +44,10 @@
                     <groupId>javax.ws.rs</groupId>
                     <artifactId>jsr311-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-starter-netflix-ribbon</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!--        <dependency>-->

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -32,6 +32,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-loadbalancer</artifactId>
+        </dependency>
         <!-- https://github.com/docker-java/docker-java/blob/master/docs/getting_started.md-->
         <dependency>
             <groupId>com.github.docker-java</groupId>

--- a/gateway/src/main/java/me/lawrenceli/gateway/config/GatewayHashRingConfig.java
+++ b/gateway/src/main/java/me/lawrenceli/gateway/config/GatewayHashRingConfig.java
@@ -1,7 +1,7 @@
 package me.lawrenceli.gateway.config;
 
 import me.lawrenceli.contant.GlobalConstant;
-import me.lawrenceli.gateway.filter.CustomLoadBalanceFilter;
+import me.lawrenceli.gateway.filter.CustomReactiveLoadBalanceFilter;
 import me.lawrenceli.gateway.server.ServiceNode;
 import me.lawrenceli.hashring.ConsistentHashRouter;
 import me.lawrenceli.hashring.VirtualNode;
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.gateway.config.LoadBalancerProperties;
+import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -31,28 +32,31 @@ public class GatewayHashRingConfig {
 
     final RedisTemplate<Object, Object> redisTemplate;
     final WebSocketProperties webSocketProperties;
+    private final LoadBalancerClientFactory clientFactory;
 
-    public GatewayHashRingConfig(RedisTemplate<Object, Object> redisTemplate, WebSocketProperties webSocketProperties) {
+    public GatewayHashRingConfig(RedisTemplate<Object, Object> redisTemplate,
+                                 WebSocketProperties webSocketProperties,
+                                 LoadBalancerClientFactory clientFactory) {
         this.redisTemplate = redisTemplate;
         this.webSocketProperties = webSocketProperties;
+        this.clientFactory = clientFactory;
     }
 
     /**
-     * 初始化自定义负载均衡过滤器
-     *
-     * @param client               bean
-     * @param properties           bean
-     * @param consistentHashRouter {@link #init() init方法}注入，此处未使用构造注入（会产生循环依赖）
-     * @return CustomLoadBalanceFilter bean
-     * @see CustomLoadBalanceFilter
+     * @param client                 负载均衡客户端
+     * @param loadBalancerProperties 负载均衡配置
+     * @param consistentHashRouter   {@link #init() init方法}注入，此处未使用构造注入（会产生循环依赖）
+     * @param discoveryClient        服务发现客户端
+     * @return 注入自定义的 Reactive 过滤器 Bean 对象
      */
     @Bean
-    public CustomLoadBalanceFilter customLoadBalanceFilter(LoadBalancerClient client,
-                                                           LoadBalancerProperties properties,
-                                                           ConsistentHashRouter<ServiceNode> consistentHashRouter,
-                                                           DiscoveryClient discoveryClient) {
-        logger.debug("初始化 CustomLoadBalanceFilter: {}, {}", client, properties);
-        return new CustomLoadBalanceFilter(client, properties, consistentHashRouter, webSocketProperties, discoveryClient);
+    public CustomReactiveLoadBalanceFilter customReactiveLoadBalanceFilter(LoadBalancerClient client,
+                                                                           LoadBalancerProperties loadBalancerProperties,
+                                                                           ConsistentHashRouter<ServiceNode> consistentHashRouter,
+                                                                           DiscoveryClient discoveryClient) {
+        logger.debug("初始化 自定义响应式负载均衡器: {}, {}", client, loadBalancerProperties);
+        return new CustomReactiveLoadBalanceFilter(clientFactory, loadBalancerProperties,
+                consistentHashRouter, discoveryClient, webSocketProperties);
     }
 
     @Bean

--- a/gateway/src/main/java/me/lawrenceli/gateway/filter/CustomLoadBalanceFilter.java
+++ b/gateway/src/main/java/me/lawrenceli/gateway/filter/CustomLoadBalanceFilter.java
@@ -1,11 +1,8 @@
 package me.lawrenceli.gateway.filter;
 
-import me.lawrenceli.contant.GlobalConstant;
 import me.lawrenceli.gateway.config.WebSocketProperties;
 import me.lawrenceli.gateway.server.ServiceNode;
 import me.lawrenceli.hashring.ConsistentHashRouter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
@@ -13,28 +10,30 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.gateway.config.LoadBalancerProperties;
 import org.springframework.cloud.gateway.filter.LoadBalancerClientFilter;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
-import org.springframework.http.server.PathContainer;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.server.ServerWebExchange;
 
 import java.net.URI;
 import java.util.List;
 
 /**
- * 自定义负载均衡策略
+ * 已废弃的自定义负载均衡过滤器
+ * - 由于旧的 LoadBalancerClientFilter 已不推荐使用，此旧实现保留，简单易懂，原理不变。
  *
  * @author lawrence
  * @since 2021/3/24
+ * @deprecated 推荐使用响应式网关的新过滤器 {@link CustomReactiveLoadBalanceFilter}
  */
 public class CustomLoadBalanceFilter extends LoadBalancerClientFilter implements BeanPostProcessor {
-
-    private static final Logger logger = LoggerFactory.getLogger(CustomLoadBalanceFilter.class);
 
     final ConsistentHashRouter<ServiceNode> consistentHashRouter;
     final WebSocketProperties webSocketProperties;
     final DiscoveryClient discoveryClient;
 
-    public CustomLoadBalanceFilter(LoadBalancerClient loadBalancer, LoadBalancerProperties properties, ConsistentHashRouter<ServiceNode> consistentHashRouter, WebSocketProperties webSocketProperties, DiscoveryClient discoveryClient) {
+    public CustomLoadBalanceFilter(LoadBalancerClient loadBalancer,
+                                   LoadBalancerProperties properties,
+                                   ConsistentHashRouter<ServiceNode> consistentHashRouter,
+                                   WebSocketProperties webSocketProperties,
+                                   DiscoveryClient discoveryClient) {
         super(loadBalancer, properties);
         this.consistentHashRouter = consistentHashRouter;
         this.webSocketProperties = webSocketProperties;
@@ -47,23 +46,7 @@ public class CustomLoadBalanceFilter extends LoadBalancerClientFilter implements
         String instancesId = originalUrl.getHost();
         if (webSocketProperties.getService().getName().equals(instancesId)) {
             // 获取需要参与哈希的字段，此项目为 userId
-            String userId = null;
-            if (originalUrl.getPath().startsWith(GlobalConstant.WEBSOCKET_ENDPOINT_PATH)) {
-                // ws: "lb://websocket-server/connect/1" 获取这里面的最后一个路径参数 userId: 1
-                List<PathContainer.Element> elements = exchange.getRequest().getPath().elements();
-                PathContainer.Element lastElement = elements.get(elements.size() - 1);
-                userId = lastElement.value();
-                logger.debug("【网关负载均衡过滤器】WebSocket 获取到 userId: {}", userId);
-            } else {
-                // 前提：websocket http 服务 userId 放在 query 中
-                // rest: "lb://websocket-server/send?userId=1&message=text"
-                MultiValueMap<String, String> queryParams = exchange.getRequest().getQueryParams();
-                List<String> userIds = queryParams.get(GlobalConstant.KEY_TO_BE_HASHED);
-                if (null != userIds && !userIds.isEmpty()) {
-                    userId = userIds.get(0);
-                    logger.debug("【网关负载均衡过滤器】HTTP 获取到 userId: {}", userId);
-                }
-            }
+            final String userId = WebSocketSessionLoadBalancer.getUserIdFromRequest(exchange);
             if (null != userId) {
                 // 请求参数中有 userId，需要经过哈希环的路由
                 ServiceNode serviceNode = consistentHashRouter.routeNode(userId);
@@ -73,7 +56,6 @@ public class CustomLoadBalanceFilter extends LoadBalancerClientFilter implements
                     for (ServiceInstance instance : instances) {
                         // 如果 userId 映射后的真实节点的 IP 与某个实例 IP 一致，就转发
                         if (instance.getHost().equals(serviceNode.getKey())) {
-                            logger.debug("当前客户端[{}]匹配到真实节点 {}", userId, serviceNode.getKey());
                             return instance;
                         }
                     }

--- a/gateway/src/main/java/me/lawrenceli/gateway/filter/CustomReactiveLoadBalanceFilter.java
+++ b/gateway/src/main/java/me/lawrenceli/gateway/filter/CustomReactiveLoadBalanceFilter.java
@@ -1,0 +1,123 @@
+package me.lawrenceli.gateway.filter;
+
+import me.lawrenceli.gateway.config.WebSocketProperties;
+import me.lawrenceli.gateway.server.ServiceNode;
+import me.lawrenceli.hashring.ConsistentHashRouter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.loadbalancer.reactive.DefaultRequest;
+import org.springframework.cloud.client.loadbalancer.reactive.Request;
+import org.springframework.cloud.client.loadbalancer.reactive.Response;
+import org.springframework.cloud.gateway.config.LoadBalancerProperties;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.ReactiveLoadBalancerClientFilter;
+import org.springframework.cloud.gateway.support.DelegatingServiceInstance;
+import org.springframework.cloud.gateway.support.NotFoundException;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_SCHEME_PREFIX_ATTR;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.addOriginalRequestUrl;
+
+/**
+ * 响应式网关的负载均衡过滤器
+ *
+ * @author lawrence
+ * @since 2021/3/29
+ */
+public class CustomReactiveLoadBalanceFilter extends ReactiveLoadBalancerClientFilter implements BeanPostProcessor {
+
+    private static final Logger logger = LoggerFactory.getLogger(CustomReactiveLoadBalanceFilter.class);
+
+    final ConsistentHashRouter<ServiceNode> consistentHashRouter;
+    final DiscoveryClient discoveryClient;
+    final WebSocketProperties webSocketProperties;
+    final LoadBalancerClientFactory clientFactory;
+    final LoadBalancerProperties properties;
+
+    public CustomReactiveLoadBalanceFilter(LoadBalancerClientFactory clientFactory,
+                                           LoadBalancerProperties properties,
+                                           ConsistentHashRouter<ServiceNode> consistentHashRouter,
+                                           DiscoveryClient discoveryClient,
+                                           WebSocketProperties webSocketProperties) {
+        super(clientFactory, properties);
+        this.clientFactory = clientFactory;
+        this.properties = properties;
+        this.consistentHashRouter = consistentHashRouter;
+        this.discoveryClient = discoveryClient;
+        this.webSocketProperties = webSocketProperties;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        URI url = exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR);
+        String schemePrefix = exchange.getAttribute(GATEWAY_SCHEME_PREFIX_ATTR);
+        if (url == null
+                || (!"lb".equals(url.getScheme()) && !"lb".equals(schemePrefix))) {
+            return chain.filter(exchange);
+        }
+        // preserve the original url
+        addOriginalRequestUrl(exchange, url);
+
+        if (logger.isTraceEnabled()) {
+            logger.trace(ReactiveLoadBalancerClientFilter.class.getSimpleName()
+                    + " url before: " + url);
+        }
+
+        return choose(exchange).doOnNext(response -> {
+            if (!response.hasServer()) {
+                throw NotFoundException.create(properties.isUse404(),
+                        "Unable to find instance for " + url.getHost());
+            }
+
+            ServiceInstance retrievedInstance = response.getServer();
+
+            URI uri = exchange.getRequest().getURI();
+
+            // if the `lb:<scheme>` mechanism was used, use `<scheme>` as the default,
+            // if the loadbalancer doesn't provide one.
+            String overrideScheme = retrievedInstance.isSecure() ? "https" : "http";
+            if (schemePrefix != null) {
+                overrideScheme = url.getScheme();
+            }
+
+            DelegatingServiceInstance serviceInstance = new DelegatingServiceInstance(
+                    retrievedInstance, overrideScheme);
+
+            URI requestUrl = reconstructURI(serviceInstance, uri);
+
+            if (logger.isTraceEnabled()) {
+                logger.trace("LoadBalancerClientFilter url chosen: " + requestUrl);
+            }
+            exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUrl);
+        }).then(chain.filter(exchange));
+    }
+
+    @SuppressWarnings("deprecation")
+    private Mono<Response<ServiceInstance>> choose(ServerWebExchange exchange) {
+        URI uri = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR);
+        assert uri != null;
+        WebSocketSessionLoadBalancer loadBalancer = new WebSocketSessionLoadBalancer(
+                clientFactory.getLazyProvider(uri.getHost(), ServiceInstanceListSupplier.class),
+                consistentHashRouter,
+                discoveryClient,
+                webSocketProperties);
+        return loadBalancer.choose(this.createRequest(exchange));
+    }
+
+    @SuppressWarnings("deprecation")
+    private Request<ServerWebExchange> createRequest(ServerWebExchange exchange) {
+        // 其实返回的 Request 对象里至少需要包含的就是负载均衡时 choose 的依据
+        return new DefaultRequest<>(exchange);
+    }
+
+}

--- a/gateway/src/main/java/me/lawrenceli/gateway/filter/WebSocketSessionLoadBalancer.java
+++ b/gateway/src/main/java/me/lawrenceli/gateway/filter/WebSocketSessionLoadBalancer.java
@@ -1,0 +1,134 @@
+package me.lawrenceli.gateway.filter;
+
+import me.lawrenceli.contant.GlobalConstant;
+import me.lawrenceli.gateway.config.WebSocketProperties;
+import me.lawrenceli.gateway.server.ServiceNode;
+import me.lawrenceli.hashring.ConsistentHashRouter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.loadbalancer.reactive.DefaultResponse;
+import org.springframework.cloud.client.loadbalancer.reactive.Request;
+import org.springframework.cloud.client.loadbalancer.reactive.Response;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.cloud.loadbalancer.core.NoopServiceInstanceListSupplier;
+import org.springframework.cloud.loadbalancer.core.RandomLoadBalancer;
+import org.springframework.cloud.loadbalancer.core.ReactorServiceInstanceLoadBalancer;
+import org.springframework.cloud.loadbalancer.core.ServiceInstanceListSupplier;
+import org.springframework.http.server.PathContainer;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * WebSocket 负载均衡器
+ *
+ * @author lawrence
+ * @since 2021/3/29
+ */
+public class WebSocketSessionLoadBalancer implements ReactorServiceInstanceLoadBalancer {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketSessionLoadBalancer.class);
+
+    final ConsistentHashRouter<ServiceNode> consistentHashRouter;
+    final DiscoveryClient discoveryClient;
+    final WebSocketProperties webSocketProperties;
+    private final ObjectProvider<ServiceInstanceListSupplier> serviceInstanceListSupplierProvider;
+
+    public WebSocketSessionLoadBalancer(ObjectProvider<ServiceInstanceListSupplier> serviceInstanceListSupplierProvider,
+                                        ConsistentHashRouter<ServiceNode> consistentHashRouter,
+                                        DiscoveryClient discoveryClient,
+                                        WebSocketProperties webSocketProperties) {
+        this.serviceInstanceListSupplierProvider = serviceInstanceListSupplierProvider;
+        this.consistentHashRouter = consistentHashRouter;
+        this.discoveryClient = discoveryClient;
+        this.webSocketProperties = webSocketProperties;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public Mono<Response<ServiceInstance>> choose(Request request) {
+        ServerWebExchange exchange = (ServerWebExchange) request.getContext();
+        URI originalUrl = (URI) exchange.getAttributes().get(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR);
+        String instancesId = originalUrl.getHost();
+        if (webSocketProperties.getService().getName().equals(instancesId)) {
+            // 获取需要参与哈希的字段，此项目为 userId
+            final String userIdFromRequest = getUserIdFromRequest(exchange);
+            if (null != userIdFromRequest) {
+                // 请求参数中有 userId，需要经过哈希环的路由
+                if (this.serviceInstanceListSupplierProvider != null) {
+                    ServiceInstanceListSupplier supplier = serviceInstanceListSupplierProvider.getIfAvailable(NoopServiceInstanceListSupplier::new);
+                    return (supplier.get()).next().map(list -> getServiceInstanceByUserId(userIdFromRequest, instancesId));
+                }
+            }
+        }
+        return choose();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public Mono<Response<ServiceInstance>> choose() {
+        logger.debug("无 userId 的请求，对于 WebSocket 服务也没有意义，随机转发...");
+        RandomLoadBalancer randomLoadBalancer = new RandomLoadBalancer(serviceInstanceListSupplierProvider, webSocketProperties.getService().getName());
+        return randomLoadBalancer.choose();
+    }
+
+    /**
+     * 哈希环的使用，根据 userId 来查询对应的节点
+     *
+     * @param userId      用户ID，关联了 WebSocket Session
+     * @param instancesId 服务名
+     * @return 服务实例的 Response
+     */
+    @SuppressWarnings("deprecation")
+    private Response<ServiceInstance> getServiceInstanceByUserId(final String userId, String instancesId) {
+        ServiceNode serviceNode = consistentHashRouter.routeNode(userId);
+        if (null != serviceNode) {
+            // 获取当前注册中心的实例
+            List<ServiceInstance> instances = discoveryClient.getInstances(instancesId);
+            for (ServiceInstance instance : instances) {
+                // 如果 userId 映射后的真实节点的 IP 与某个实例 IP 一致，就转发
+                if (instance.getHost().equals(serviceNode.getKey())) {
+                    logger.debug("当前客户端[{}]匹配到真实节点 {}", userId, serviceNode.getKey());
+                    return new DefaultResponse(instance);
+                }
+            }
+        }
+        logger.warn("网关监测到当前无哈希环, 即无 WebSocket 服务实例，尝试取第一个实例，可能为 null");
+        return new DefaultResponse(discoveryClient.getInstances(instancesId).get(0));
+    }
+
+    /**
+     * 从 WS/HTTP 请求 中获取待哈希字段 userId
+     *
+     * @param exchange 请求上下文
+     * @return userId，可能为空
+     */
+    protected static String getUserIdFromRequest(ServerWebExchange exchange) {
+        URI originalUrl = (URI) exchange.getAttributes().get(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR);
+        String userId = null;
+        if (originalUrl.getPath().startsWith(GlobalConstant.WEBSOCKET_ENDPOINT_PATH)) {
+            // ws: "lb://websocket-server/connect/1" 获取这里面的最后一个路径参数 userId: 1
+            List<PathContainer.Element> elements = exchange.getRequest().getPath().elements();
+            PathContainer.Element lastElement = elements.get(elements.size() - 1);
+            userId = lastElement.value();
+            logger.debug("【网关负载均衡】WebSocket 获取到 userId: {}", userId);
+        } else {
+            // 前提：websocket http 服务 userId 放在 query 中
+            // rest: "lb://websocket-server/send?userId=1&message=text"
+            MultiValueMap<String, String> queryParams = exchange.getRequest().getQueryParams();
+            List<String> userIds = queryParams.get(GlobalConstant.KEY_TO_BE_HASHED);
+            if (null != userIds && !userIds.isEmpty()) {
+                userId = userIds.get(0);
+                logger.debug("【网关负载均衡】HTTP 获取到 userId: {}", userId);
+            }
+        }
+        return userId;
+    }
+
+}


### PR DESCRIPTION
Fixed: #4 

采用 Spring Cloud Gateway 响应式的过滤器，网关能够非阻塞地进行哈希路由。
实现 `ReactiveLoadBalancerClientFilter` 和 `ReactorServiceInstanceLoadBalancer` 来自定义负载均衡策略。